### PR TITLE
refactor: self-contained presets

### DIFF
--- a/src/configs/jsdoc.ts
+++ b/src/configs/jsdoc.ts
@@ -2,7 +2,7 @@ import type { Config } from '../types'
 
 import { interopDefault } from '../utils'
 
-export async function jsdoc(options: { stylistic?: boolean } = {}): Promise<Config[]> {
+export async function jsdocPreset(options: { stylistic?: boolean } = {}): Promise<Config[]> {
   const {
     stylistic = true,
   } = options

--- a/src/configs/jsonc.ts
+++ b/src/configs/jsonc.ts
@@ -2,11 +2,11 @@ import type { Config } from "../types";
 import { interopDefault } from "../utils";
 
 /**
- * Base JSONC setup - enables the parser and plugin.
- * This should be included when ANY JSON-related option is enabled.
+ * JSONC rules for all JSON files.
+ * Includes jsonc plugin and parser setup.
+ * Only applied when `jsonc: true` is set.
  */
-export async function jsoncSetup(): Promise<Config[]> {
-
+export async function jsoncPreset(): Promise<Config[]> {
     const [
         eslintPluginJsonc, jsoncEslintParser,
     ] = await Promise.all([
@@ -16,29 +16,17 @@ export async function jsoncSetup(): Promise<Config[]> {
 
     return [
         {
-            name: "schplitt/eslint-config:jsonc/setup",
+            name: "schplitt/eslint-config:jsonc",
+            files: ["**/*.json", "**/*.json5", "**/*.jsonc"],
             plugins: {
                 jsonc: eslintPluginJsonc as any,
             },
-        },
-        {
-            name: "schplitt/eslint-config:jsonc/parser",
-            files: ["**/*.json", "**/*.json5", "**/*.jsonc"],
             languageOptions: {
                 parser: jsoncEslintParser,
             },
-        },
-    ];
-}
-
-/**
- * General JSONC rules for all JSON files.
- * Only applied when `jsonc: true` is set.
- */
-export function jsoncRules(): Config[] {
-    return [
-        {
-         
+            rules: {
+                // Add JSONC rules here when needed
+            },
         },
     ];
 }

--- a/src/configs/package-json.ts
+++ b/src/configs/package-json.ts
@@ -1,4 +1,5 @@
 import type { Config } from "../types";
+import { interopDefault } from "../utils";
 
 /**
  * All possible package.json keys in a strict, opinionated order.
@@ -182,15 +183,28 @@ const gitHooksOrder = [
 /**
  * Sort package.json keys and values
  *
- * Requires `eslint-plugin-jsonc` to be installed and configured
+ * Includes jsonc plugin and parser setup.
  *
  * @see https://ota-meshi.github.io/eslint-plugin-jsonc/rules/sort-keys.html
  */
-export function packageJsonPreset(): Config[] {
+export async function packageJsonPreset(): Promise<Config[]> {
+    const [
+        eslintPluginJsonc, jsoncEslintParser,
+    ] = await Promise.all([
+        interopDefault(import("eslint-plugin-jsonc")),
+        interopDefault(import("jsonc-eslint-parser")),
+    ]);
+
     return [
         {
             name: "schplitt/eslint-config:package-json",
             files: ["**/package.json"],
+            plugins: {
+                jsonc: eslintPluginJsonc as any,
+            },
+            languageOptions: {
+                parser: jsoncEslintParser,
+            },
             rules: {
                 // Sort the "files" array alphabetically
                 "jsonc/sort-array-values": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { FlatConfigComposer } from "eslint-flat-config-utils";
-import { jsoncRules, jsoncSetup, packageJsonPreset } from "./configs";
+import { jsoncPreset, packageJsonPreset } from "./configs";
 import type { Awaitable, Config, Options } from "./types";
 import { ignoresPreset } from "./configs/ignores";
-import { jsdoc } from "./configs/jsdoc";
+import { jsdocPreset } from "./configs/jsdoc";
 
 
 
@@ -25,21 +25,14 @@ export function schplitt(options: Options = {}): FlatConfigComposer<Config> {
     // defaults
     configs.push(
         ignoresPreset(ignores),
-        jsdoc({ stylistic })
+        jsdocPreset({ stylistic })
     )
 
+    // Each config brings its own plugin and parser setup
+    // They will override themselves, which is fine
 
-    // Check if ANY JSON-related option is enabled
-    const needsJsoncPlugin = packageJson || jsonc || tsconfig;
-
-    if (needsJsoncPlugin) {
-        // Enable jsonc plugin and parser ONCE for all JSON files
-        configs.push(jsoncSetup());
-    }
-
-    // Add specific rules only when their option is enabled
     if (jsonc) {
-        configs.push(jsoncRules());
+        configs.push(jsoncPreset());
     }
 
     if (packageJson) {


### PR DESCRIPTION
Refactor the configuration functions to be self-contained presets, improving modularity and clarity in the setup of JSONC and JSDoc configurations. This change enhances the organization of the code and ensures that each preset manages its own dependencies.