### PR TITLE
fix(node): restrict rules to JS/TS files only

### DIFF
--- a/src/configs/node.ts
+++ b/src/configs/node.ts
@@ -1,4 +1,5 @@
 import type { Config } from '../types'
+import { COMPLETE_JS_TS_GLOB } from '../globs'
 import pluginNode from 'eslint-plugin-n'
 
 /**
@@ -9,6 +10,7 @@ export async function nodePreset(): Promise<Config[]> {
   return [
     {
       name: 'schplitt/eslint-config:node',
+      files: [COMPLETE_JS_TS_GLOB],
       plugins: {
         node: pluginNode,
       },


### PR DESCRIPTION
Prevent Node.js ESLint rules from applying to Angular HTML templates by adding file glob restrictions.